### PR TITLE
Kb missing (#7)

### DIFF
--- a/Car_Recommender/data/krf/car-kb.krf
+++ b/Car_Recommender/data/krf/car-kb.krf
@@ -90,8 +90,7 @@
 (engineCityFuelEconomyMpg RAV4-Standard-Engine 28)
 (engineHighwayFuelEconomyMpg RAV4-Standard-Engine 35)
 (engineTypeOf RAV4-Standard-Engine 2.5L-4-Cylinder)
-
-
+(engineCO2Emission RAV4-Standard-Engine 199)
 
 ;;;; ---------------------------------------------------------------------------
 
@@ -139,6 +138,7 @@
 (engineCityFuelEconomyMpg CR-V-Standard-Engine 28) ; Assuming 28 mpg in city
 (engineHighwayFuelEconomyMpg CR-V-Standard-Engine 34) ; Assuming 34 mpg on highway
 (engineTypeOf CR-V-Standard-Engine 1.5L-Turbocharged-4-Cylinder)
+(engineCO2Emission CR-V-Standard-Engine 134)
 
 
 ;;;; ---------------------------------------------------------------------------
@@ -184,6 +184,8 @@
 (EngineTopSpeedMph Model-Y-Dual-Motor 135) ; Top speed in mph
 (EngineRangeMiles Model-Y-Dual-Motor 326) ; Estimated range in miles
 (EngineTypeOf Model-Y-Dual-Motor Dual-Motor-All-Wheel-Drive)
+;;; !!! MISSING - engineTorqueNm
+;;; !!! MISSING - needs a predicate that states that engine is electric
 
 
 ;;;; ---------------------------------------------------------------------------

--- a/Car_Recommender/data/krf/car-ontology.krf
+++ b/Car_Recommender/data/krf/car-ontology.krf
@@ -173,5 +173,22 @@ fuel economy in highway driving conditions, measured in mpg.")
 (arg1Isa carTransmission Car)
 (arg2Isa carTransmission Transmission)
 
+
+;;;;;;;;;;;;;;;;; Car Rule Collections ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(isa LuxurySUV Collection)
+(genls LuxurySUV Car)
+
+(isa CompactSUV Collection)
+(genls CompactSUV Car)
+
+(isa SportsCar Collection)
+(genls SportsCar Car)
+
+(isa OffRoad Collection)
+(genls OffRoad Car)
+
+(isa VTOL Collection)
+(genls VTOL Car)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; End of Code

--- a/Car_Recommender/data/krf/car-rules-us.krf
+++ b/Car_Recommender/data/krf/car-rules-us.krf
@@ -1,0 +1,44 @@
+;;;; -*-  Mode: LISP; Syntax: Common-Lisp; Base: 10                          -*-
+;;;; ---------------------------------------------------------------------------
+;;;; ---------------------------------------------------------------------------
+
+(in-microtheory CarWorldMt)
+
+(isa CarRulesUS Microtheory)
+(comment CarRulesUS "CarRulesUS is a microtheory to define hornclauses related to car categories in the Unites States.")
+
+(genlMt CarRulesUS CarWorldMt)
+
+;;; LuxurySUV
+"(<== (isa ?car LuxurySUV)
+(numberOfDoors ?car ?doors) (greaterThan ?doors 4)
+(cargoVolume ?car ?cargovol) (greaterThan ?cargovol 15)
+(carLength ?car ?length) (greaterThan ?length 180)
+(carWidth ?car ?width) (greaterThan ?width 60)
+(carHeight ?car ?height) (greaterThan ?height 65)
+(mainEngine ?car ?engine) (engineHP ?engine ?ehp) (greaterThan ?ehp 250)
+(mainEngine ?car ?engine) (engineAcceleration62 ?engine ?eam) (lessThan ?eam 7)
+(mainEngine ?car ?engine) (engineTopSpeedMph ?engine ?etsm) (greaterThan ?etsm 120)
+(mainEngine ?car ?engine) (engineTorqueNm ?engine ?etn) (greaterThan ?etn 300)
+(mainEngine ?car ?engine) (engineFuelCapacityGl ?engine ?efcg)
+(mainEngine ?car ?engine) (engineCityFuelEconomyMpg ?engine ?ecfem) (greaterThan ?ecfem 10)
+(mainEngine ?car ?engine) (engineHighwayFuelEconomyMpg ?engine ?ehfem) (greaterThan ?ehfem 10)
+(mainEngine ?car ?engine) (engineCO2Emission ?engine ?ecoe)
+)"
+
+;;; Compact SUV
+"(<== (isa ?car CompactSUV)
+(cargoVolume ?car ?cargovol) (greaterThan ?cargovol 15)
+(carLength ?car ?length) (and (greaterThan ?length 170) (lessThan ?length 190))
+(carWidth ?car ?width) (greaterThan ?width 70)
+(carHeight ?car ?height) (greaterThan ?height 60)
+(mainEngine ?car ?engine) (engineHP ?engine ?ehp) (greaterThan ?ehp 150)
+(mainEngine ?car ?engine) (engineAcceleration62 ?engine ?eam) (lessThan ?eam 10)
+(mainEngine ?car ?engine) (engineTopSpeedMph ?engine ?etsm) (greaterThan ?etsm 100)
+(mainEngine ?car ?engine) (engineTorqueNm ?engine ?etn) (greaterThan ?etn 200)
+(mainEngine ?car ?engine) (engineFuelCapacityGl ?engine ?efcg) (greaterThan ?efcg 10)
+(mainEngine ?car ?engine) (engineCityFuelEconomyMpg ?engine ?ecfem) (greaterThan ?ecfem 20)
+(mainEngine ?car ?engine) (engineHighwayFuelEconomyMpg ?engine ?ehfem) (greaterThan ?ehfem 25)
+(mainEngine ?car ?engine) (engineCO2Emission ?engine ?ecoe) (lessThan ?ecoe 250)
+(carTransmission ?car ?transmission)
+)"


### PR DESCRIPTION
* rule - US - luxurySUV

* ontology - collection - car rules

* add co2 emission for toyota rav4 2023 into cars kb

* added co2 emission for Honda-CR-V-2023

* created hornclause - compact suv

* missing - engineTorqueNm - tesla model y 2021

* missing - electric engine - tesla model y 2021